### PR TITLE
fix error - "not in a supported availability"

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -100,7 +100,7 @@ module "vpc" {
   name = local.name
   cidr = "10.99.0.0/18"
 
-  azs              = ["${local.region}a", "${local.region}b", "${local.region}d"] # Caution: check which zones are available
+  azs              = ["${local.region}a", "${local.region}c", "${local.region}d"] # Caution: check which zones are available
   private_subnets  = ["10.99.0.0/24", "10.99.1.0/24", "10.99.2.0/24"]
   database_subnets = ["10.99.3.0/24", "10.99.4.0/24", "10.99.5.0/24"]
 


### PR DESCRIPTION
fix the example. By default it throws this:

```
Error: creating MemoryDB Subnet Group (memorydb-ex-complete-subnet-group): SubnetNotAllowedFault: Subnets: [subnet-xxx] are not in a supported availability zone. Supported availability zones are [us-east-1d, us-east-1a, us-east-1c].
```